### PR TITLE
Provide actionable error for Download job translated files action

### DIFF
--- a/Apps.Matecat/Actions/JobActions.cs
+++ b/Apps.Matecat/Actions/JobActions.cs
@@ -54,7 +54,16 @@ public class JobActions : BaseInvocable
     {
         var endpoint = $"/api/v3{ApiEndpoints.Translation}/{jobId}";
         var request = new MatecatRequest(endpoint, Method.Get, Creds);
-        var response = await _client.ExecuteWithHandling(request);
+
+        RestResponse response;
+        try
+        {
+            response = await _client.ExecuteWithHandling(request);
+        }
+        catch (PluginApplicationException ex) when (ex.Message.Contains("Typed property API\\V2\\DownloadFileController::$job must be an instance of Jobs_JobStruct, null used"))
+        {
+            throw new PluginMisconfigurationException("Job not found or password was changed.", ex);
+        }
 
         using var stream = new MemoryStream(response.RawBytes);
         if (response.ContentType == MediaTypeNames.Application.Zip)

--- a/Apps.Matecat/Actions/JobActions.cs
+++ b/Apps.Matecat/Actions/JobActions.cs
@@ -62,7 +62,7 @@ public class JobActions : BaseInvocable
         }
         catch (PluginApplicationException ex) when (ex.Message.Contains("Typed property API\\V2\\DownloadFileController::$job must be an instance of Jobs_JobStruct, null used"))
         {
-            throw new PluginMisconfigurationException("Job not found or password was changed.", ex);
+            throw new PluginApplicationException("Job not found or password was changed.");
         }
 
         using var stream = new MemoryStream(response.RawBytes);


### PR DESCRIPTION
Display a clear error message when a job is not found or the password is incorrect during the "Download job translated files" action